### PR TITLE
It would max at 2 or 3 reviews and stop

### DIFF
--- a/Web scraping Hilton Hawaiian Village TripAdvisor Reviews.py
+++ b/Web scraping Hilton Hawaiian Village TripAdvisor Reviews.py
@@ -97,7 +97,7 @@ def get_reviews_ids(soup):
     items = soup.find_all('div', attrs={'data-reviewid': True})
 
     if items:
-        reviews_ids = [x.attrs['data-reviewid'] for x in items][::2]
+        reviews_ids = [x.attrs['data-reviewid'] for x in items]
         print('[get_reviews_ids] data-reviewid:', reviews_ids)
         return reviews_ids
     


### PR DESCRIPTION
removing the ::2 index allows the scrapper to find the 5 reviews then go to the next page.

If you don't the script thinks it has found all reviews on the first page then stops.

I think tripadvisor updated their website so this happened.